### PR TITLE
Replace per-event thread spawning with a shared scheduler

### DIFF
--- a/src/main/java/xyz/yourboykyle/secretroutes/dungeons/SecretUtils.java
+++ b/src/main/java/xyz/yourboykyle/secretroutes/dungeons/SecretUtils.java
@@ -486,13 +486,7 @@ public class SecretUtils {
 
                 if (first) {
                     removeBannerTime = System.currentTimeMillis() + 5000;
-                    new Thread(() -> {
-                        try {
-                            Thread.sleep(5000);
-                            removeBannerTime = null;
-                        } catch (InterruptedException ignored) {
-                        }
-                    }).start();
+                    SchedulerUtils.schedule(5000, () -> removeBannerTime = null);
                     first = false;
                 }
             }

--- a/src/main/java/xyz/yourboykyle/secretroutes/events/OnChatReceive.java
+++ b/src/main/java/xyz/yourboykyle/secretroutes/events/OnChatReceive.java
@@ -84,15 +84,11 @@ public class OnChatReceive {
         }
         if (formatted.startsWith("§r§cThat chest is locked")) {
             LogUtils.info("§aLocked chest detected!");
-            new Thread(() -> {
-                try {
-                    Thread.sleep(100);
-                } catch (InterruptedException ignored) {
-                }
+            SchedulerUtils.schedule(100, () -> {
                 if (SecretUtils.lastInteract != null) {
                     SecretUtils.secretLocations.remove(BlockUtils.blockPos(SecretUtils.lastInteract));
                 }
-            }).start();
+            });
             SecretUtils.renderLever = true;
 
             if (Main.currentRoom.currentSecretRoute != null && Main.currentRoom.currentSecretIndex > 0) {

--- a/src/main/java/xyz/yourboykyle/secretroutes/events/OnPlayerInteract.java
+++ b/src/main/java/xyz/yourboykyle/secretroutes/events/OnPlayerInteract.java
@@ -129,14 +129,7 @@ public class OnPlayerInteract {
 
                         // Stuff so items from chests don't count as secrets (because they're not)
                         OnItemPickedUp.itemSecretOnCooldown = true;
-                        new Thread(() -> {
-                            try {
-                                Thread.sleep(2000);
-                                OnItemPickedUp.itemSecretOnCooldown = false;
-                            } catch (InterruptedException ex) {
-                                LogUtils.error(ex);
-                            }
-                        }).start();
+                        SchedulerUtils.schedule(2000, () -> OnItemPickedUp.itemSecretOnCooldown = false);
                     }
                 }
             }

--- a/src/main/java/xyz/yourboykyle/secretroutes/utils/SchedulerUtils.java
+++ b/src/main/java/xyz/yourboykyle/secretroutes/utils/SchedulerUtils.java
@@ -1,0 +1,66 @@
+//#if FABRIC
+/*
+ * Secret Routes Mod - Secret Route Waypoints for Hypixel Skyblock Dungeons
+ * Copyright 2025 yourboykyle & R-aMcC & christechs
+ *
+ * <DO NOT REMOVE THIS COPYRIGHT NOTICE>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package xyz.yourboykyle.secretroutes.utils;
+
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Shared scheduler for delayed actions.
+ * <p>
+ * Previously every delayed action allocated its own {@link Thread} that spent nearly all of its
+ * lifetime inside {@link Thread#sleep(long)}. Room loads and chat events can fire many times per
+ * run, so that pattern created thousands of short-lived threads per session. A single daemon
+ * scheduler does the same job without the per-event thread allocation.
+ */
+public class SchedulerUtils {
+
+    private static final ScheduledExecutorService SCHEDULER = Executors.newSingleThreadScheduledExecutor(runnable -> {
+        Thread thread = new Thread(runnable, "SecretRoutes-Scheduler");
+        thread.setDaemon(true);
+        return thread;
+    });
+
+    private SchedulerUtils() {
+    }
+
+    /**
+     * Runs {@code task} after {@code delayMs} milliseconds on the shared scheduler thread.
+     * <p>
+     * The task is <b>not</b> run on the client thread. Callers that touch game state must hop back
+     * themselves, e.g. via {@code Minecraft.getInstance().execute(...)}.
+     *
+     * @param delayMs delay in milliseconds
+     * @param task    the action to run
+     */
+    public static void schedule(long delayMs, Runnable task) {
+        SCHEDULER.schedule(() -> {
+            try {
+                task.run();
+            } catch (Exception ex) {
+                LogUtils.error(ex);
+            }
+        }, delayMs, TimeUnit.MILLISECONDS);
+    }
+}
+//#endif


### PR DESCRIPTION
### Problem

Three delayed actions each allocate a dedicated `Thread` that spends essentially its entire lifetime inside `Thread.sleep()`:

| Location | Delay | Purpose |
|---|---|---|
| `OnPlayerInteract.java:132` | 2000ms | reset `itemSecretOnCooldown` |
| `OnChatReceive.java:87` | 100ms | remove `lastInteract` from `secretLocations` |
| `SecretUtils.java:489` | 5000ms | reset `removeBannerTime` |

Each fires per interaction or per matching chat message, so a session accumulates a large number of short-lived threads whose only job is to flip a field once the delay elapses. Every one reserves its own stack for the duration.

### Change

Adds `SchedulerUtils` — a single daemon `ScheduledExecutorService` — and routes the three call sites through it.

```java
// before
OnItemPickedUp.itemSecretOnCooldown = true;
new Thread(() -> {
    try {
        Thread.sleep(2000);
        OnItemPickedUp.itemSecretOnCooldown = false;
    } catch (InterruptedException ex) {
        LogUtils.error(ex);
    }
}).start();

// after
OnItemPickedUp.itemSecretOnCooldown = true;
SchedulerUtils.schedule(2000, () -> OnItemPickedUp.itemSecretOnCooldown = false);
```

### Behaviour

Unchanged. The callbacks still run **off** the client thread after the same delays, matching the previous semantics — `SchedulerUtils.schedule` documents this explicitly so callers touching game state know to hop back via `Minecraft.getInstance().execute(...)`. Exceptions are reported through `LogUtils.error` just as the old `catch` blocks did. The scheduler thread is a daemon and named `SecretRoutes-Scheduler`, so it won't hold up JVM shutdown and is identifiable in thread dumps.

Net: **−21 / +4** at the call sites, plus the new utility.

### Scope

Deliberately limited to the three sites that are pure *"sleep, then set a field"*. `OnPlaySound.java:58` and `OnMouseInput.java:86` also use `new Thread` + `sleep`, but they run multi-step sequences that read player state mid-way, so converting them is a behavioural question rather than a mechanical one — left alone here to keep the diff reviewable. Happy to follow up on those separately if you'd like.

### Testing

`./gradlew compileJava` passes on the active `26.2` target. The change is plain Java with no version-specific API, so it's independent of the Stonecutter target; the new file carries the same `//#if FABRIC` guard as the surrounding `utils` classes.

I have not been able to verify the timing behaviour in a live dungeon run — worth a sanity check on your side that the locked-chest and banner resets still feel right.
